### PR TITLE
Add STD topographic descriptor

### DIFF
--- a/topo_descriptors/topo.py
+++ b/topo_descriptors/topo.py
@@ -135,7 +135,7 @@ def circular_kernel(size):
     return kernel
 
 
-def compute_std(dem_da, scales, smth_factors=None, ind_nans=[], crop=None):
+def compute_std(dem_da, scales, smth_factors=None, ind_nans=[], crop=None, outdir="."):
     """Wrapper to 'std' function to launch computations for all scales and save
     outputs as netCDF files.
 
@@ -159,6 +159,8 @@ def compute_std(dem_da, scales, smth_factors=None, ind_nans=[], crop=None):
         If specified the outputs are cropped to the given extend. Keys should be
         the coordinates labels of dem_da and values should be slices of [min,max]
         extend. Default is None.
+    outdir (optional) : string
+        The path to the output directory. Save to working directory by default.
 
     See also
     --------
@@ -184,7 +186,7 @@ def compute_std(dem_da, scales, smth_factors=None, ind_nans=[], crop=None):
         array = std(dem=dem_da.values, size=scale_pxl, sigma=sigmas[idx])
 
         array[ind_nans] = np.nan
-        hlp.to_netcdf(array, dem_da.coords, name, crop)
+        hlp.to_netcdf(array, dem_da.coords, name, crop, outdir)
         del array
 
 

--- a/topo_descriptors/topo.py
+++ b/topo_descriptors/topo.py
@@ -30,7 +30,7 @@ def compute_tpi(dem_da, scales, smth_factors=None, ind_nans=[], crop=None):
         Contains the (row, column) indices of the NaNs in the original DEM to be
         reassigned after computations. NaNs in the original DEM should be
         interpolated prior computations as they propagate in convolutions with
-        the fast fourrier transform method (scipy.signal.convolve).
+        the fast Fourier transform method (scipy.signal.convolve).
     crop (optional) : dict
         If specified the outputs are cropped to the given extend. Keys should be
         the coordinates labels of dem_da and values should be slices of [min,max]
@@ -152,7 +152,7 @@ def compute_std(dem_da, scales, smth_factors=None, ind_nans=[], crop=None):
         Contains the (row, column) indices of the NaNs in the original DEM to be
         reassigned after computations. NaNs in the original DEM should be
         interpolated prior computations as they propagate in convolutions with
-        the fast fourrier transform method (scipy.signal.convolve).
+        the fast Fourier transform method (scipy.signal.convolve).
     crop (optional) : dict
         If specified the outputs are cropped to the given extend. Keys should be
         the coordinates labels of dem_da and values should be slices of [min,max]
@@ -252,7 +252,7 @@ def compute_valley_ridge(
     mode : {valley, ridge}
         Whether to compute the valley or ridge index.
     flat_list (optional) : list of floats in [0,1[
-        Fractions of flat along the center ligne of the V-shape kernels. A certain
+        Fractions of flat along the center line of the V-shape kernels. A certain
         amount of flat is use to approximate the shape of glacial valleys.
         Default is [0, 0.15, 0.3].
     smth_factors (optional) : scalar or None or list with a combination of both.
@@ -264,7 +264,7 @@ def compute_valley_ridge(
         Contains the (row, column) indices of the NaNs in the original DEM to be
         reassigned after computations. NaNs in the original DEM should be
         interpolated prior computations as they propagate in convolutions with
-        the fast fourrier transform method (scipy.signal.convolve).
+        the fast Fourier transform method (scipy.signal.convolve).
     crop (optional) : dict
         If specified the outputs are cropped to the given extend. Keys should be
         the coordinates labels of dem_da and values should be slices of [min,max]
@@ -334,7 +334,7 @@ def valley_ridge(dem, size, mode, flat_list=[0, 0.15, 0.3], sigma=None):
     mode : {valley, ridge}
         Whether to compute the valley or ridge index.
     flat_list (optional) : list of floats in [0,1[
-        Fractions of flat along the center ligne of the V-shape kernels. A certain
+        Fractions of flat along the center line of the V-shape kernels. A certain
         amount of flat is use to approximate the shape of glacial valleys.
         Default is [0, 0.15, 0.3].
     sigma (optional) : scalar
@@ -406,7 +406,7 @@ def _valley_kernels(size, flat_list):
     size : int
         Size of the kernel.
     flat_list : list of floats in [0,1[
-        Fractions of flat along the center ligne of the V-shape kernels. A certain
+        Fractions of flat along the center line of the V-shape kernels. A certain
         amount of flat is use to approximate the shape of glacial valleys.
 
     Returns
@@ -442,7 +442,7 @@ def _ridge_kernels(size, flat_list):
     size : int
         Size of the kernel.
     flat_list : list of floats in [0,1[
-        Fractions of flat along the center ligne of the V-shape kernels. A certain
+        Fractions of flat along the center line of the V-shape kernels. A certain
         amount of flat is use to approximate the shape of glacial valleys.
 
     Returns

--- a/topo_descriptors/topo.py
+++ b/topo_descriptors/topo.py
@@ -214,7 +214,7 @@ def std(dem, size, sigma=None):
     if sigma:
         dem = ndimage.gaussian_filter(dem, sigma)
 
-    squared_dem = dem.astype("float32") ** 2
+    squared_dem = dem.astype("int32") ** 2
     sum_dem = signal.convolve(dem, kernel, mode="same")
     sum_squared_dem = signal.convolve(squared_dem, kernel, mode="same")
 

--- a/topo_descriptors/topo.py
+++ b/topo_descriptors/topo.py
@@ -38,7 +38,7 @@ def compute_tpi(dem_da, scales, smth_factors=None, ind_nans=[], crop=None):
 
     See also
     --------
-    tpi, _tpi_kernel
+    tpi, circular_kernel
     """
 
     hlp.check_dem(dem_da)
@@ -88,7 +88,10 @@ def tpi(dem, size, sigma=None):
     scipy.signal.convolve, scipy.ndimage.gaussian_filter
     """
 
-    kernel = _tpi_kernel(size)
+    kernel = circular_kernel(size)
+    # exclude mid point from the kernel
+    kernel[int(size / 2), int(size / 2)] = 0
+
     if sigma:
         dem = ndimage.gaussian_filter(dem, sigma)
 
@@ -105,13 +108,14 @@ def _tpi_name(scale, smth_factor):
     return f"TPI_{scale}M{add}"
 
 
-def _tpi_kernel(size):
-    """Generate a circular kernel to compute TPI.
+def circular_kernel(size):
+    """Generate a circular kernel.
 
     Parameters
     ----------
     size : int
-        Size of the kernel.
+        Size of the circular kernel (its diameter). For size < 5, the kernel is
+        a square instead of a circle.
 
     Returns
     -------
@@ -126,7 +130,6 @@ def _tpi_kernel(size):
         circle = (xx - middle) ** 2 + (yy - middle) ** 2
         kernel = np.asarray(circle <= (middle ** 2), dtype=np.float32)
 
-    kernel[middle, middle] = 0
     return kernel
 
 
@@ -157,7 +160,7 @@ def compute_std(dem_da, scales, smth_factors=None, ind_nans=[], crop=None):
 
     See also
     --------
-    std, _tpi_kernel
+    std, circular_kernel
     """
 
     hlp.check_dem(dem_da)
@@ -206,7 +209,7 @@ def std(dem, size, sigma=None):
     --------
     scipy.signal.convolve, scipy.ndimage.gaussian_filter
     """
-    kernel = _tpi_kernel(size)
+    kernel = circular_kernel(size)
     kernel_sum = np.sum(kernel)
     if sigma:
         dem = ndimage.gaussian_filter(dem, sigma)


### PR DESCRIPTION
Implement new topographic descriptor as a rolling standard deviation.

The local topographic variance is computed as the mean squared elevation minus the squared mean elevation (ie. var(X) = E(X^2) - E(X)^2) within a neighborhood. This allows fast computation with 2d convolution.
Because of rounding errors, the variance is clipped to 0 before computing the standard deviation (this is a problem only in flat areas like lakes). 

Example output (special prize if you can guess where this is!):
- 500m scale:
![image](https://user-images.githubusercontent.com/11967971/120811698-8c7b2880-c54c-11eb-90ae-410b9d822815.png)
- 5000m scale
![image](https://user-images.githubusercontent.com/11967971/120812067-f398dd00-c54c-11eb-9b02-d4ffe6c806dc.png)

