### PR TITLE
Faster TPI computation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ from setuptools import setup, find_packages
 requirements = [
     "netcdf4",
     "numba",
+    "dask",
     "numpy",
     "pandas",
     "scipy",

--- a/topo_descriptors/topo.py
+++ b/topo_descriptors/topo.py
@@ -104,10 +104,8 @@ def tpi(dem, size, sigma=None):
     )
 
     if isinstance(dem.data, da.Array):
-        print("dask")
         conv = da.map_overlap(conv_fn, dem.data, depth=size * 2, boundary="none")
     elif isinstance(dem.data, np.ndarray):
-        print("numpy")
         conv = conv_fn(dem.values)
     return dem - conv / np.sum(kernel)
 

--- a/topo_descriptors/topo.py
+++ b/topo_descriptors/topo.py
@@ -99,7 +99,9 @@ def tpi(dem, size, sigma=None):
 
     if sigma:
         dem = ndimage.gaussian_filter(dem, sigma)
-    conv_fn = lambda a: ndimage.convolve(a, kernel, mode="constant", cval=np.nan)
+    conv_fn = lambda a: ndimage.convolve(
+        a, kernel, mode="constant", cval=np.nan, origin=-1
+    )
 
     if isinstance(dem.data, da.Array):
         print("dask")

--- a/topo_descriptors/topo.py
+++ b/topo_descriptors/topo.py
@@ -99,9 +99,8 @@ def tpi(dem, size, sigma=None):
 
     if sigma:
         dem = ndimage.gaussian_filter(dem, sigma)
-    conv_fn = lambda a: ndimage.convolve(
-        a, kernel, mode="constant", cval=np.nan, origin=-1
-    )
+
+    conv_fn = lambda a: signal.convolve(a, kernel, mode="same")
 
     if isinstance(dem.data, da.Array):
         conv = da.map_overlap(conv_fn, dem.data, depth=size * 2, boundary="none")


### PR DESCRIPTION
I changed the code for the TPI computation to improve performance. 
- use dask's `map_overlap` function to spread the computation over multiple threads (note that this could be applied to other descriptors in the future)

Nothing changes in terms of API.