### PR TITLE
fix: remove parralelization with multiprocessing

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,13 +2,14 @@
 History
 =======
 
-0.3.0 (2023-12-20)
+0.3.0 (2024-01-15)
 ------------------
 
 * Move from DataArray to Dataset for DEM object to allow transferring global attributes.
 * Add units as variable attributes.
 * Output slope in units of [degree] instead of [m / pixel].
 * Fix bug in slope calculation.
+* Remove parallelization of scales with multiprocessing for valley and ridge
 
 0.2.1 (2022-10-19)
 ------------------


### PR DESCRIPTION
For valley and ridge computations, some custom parallelization of the scales using multiprocesssing (in particular cpu.count()) was implemented making the library too much platform dependant and not integrating well with SLURM.

This was remove so parralelization of scales can be left at the user level (e.g. using snakemake)